### PR TITLE
Can't mute audio

### DIFF
--- a/Source/Player.swift
+++ b/Source/Player.swift
@@ -138,10 +138,10 @@ public class Player: UIViewController {
     
     public var muted: Bool! {
         get {
-            return self.playerView.player.muted
+            return self.player.muted
         }
         set {
-            self.playerView.player.muted = newValue
+            self.player.muted = newValue
         }
     }
     


### PR DESCRIPTION
Fixes #22 Getting and setting the `self.muted` variable was done through `self.playerView.player` which was `nil`. Set using `self.player` instead because Player owns it already. 

An alternative if you wanted to keep using `self.playerView.player` is set `self.playerView.player = self.player` in the `loadView()` method.