### PR TITLE
Fix a crash in deinit

### DIFF
--- a/Source/Player.swift
+++ b/Source/Player.swift
@@ -209,12 +209,12 @@ public class Player: UIViewController {
     }
 
     deinit {
-        self.playerView.player = nil
+        self.playerView?.player = nil
         self.delegate = nil
 
         NSNotificationCenter.defaultCenter().removeObserver(self)
 
-        self.playerView.layer.removeObserver(self, forKeyPath: PlayerReadyForDisplay, context: &PlayerLayerObserverContext)
+        self.playerView?.layer.removeObserver(self, forKeyPath: PlayerReadyForDisplay, context: &PlayerLayerObserverContext)
 
         self.player.removeObserver(self, forKeyPath: PlayerRateKey, context: &PlayerObserverContext)
 


### PR DESCRIPTION
I'm not sure why this happened. But when I unwind a view controller with some `Player`s in it, it crashes in `deinit`. Turns out `self.playerView` is already nil.