### PR TITLE
Resume video when view is visible (closes #31) Remove warnings in Xcode 7.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
-osx_image: xcode7.2
+osx_image: xcode7.3
 env:
   global:
   - LC_CTYPE=en_US.UTF-8

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,5 +9,5 @@ before_install:
   - brew reinstall xctool
 script:
   - xcodebuild -showsdks
-  - xctool -project Project/Player.xcodeproj -scheme 'Debug - iOS' -sdk iphonesimulator9.2 build analyze
-#  - xctool -project Project/Player.xcodeproj -scheme 'Debug - tvOS' -sdk appletvsimulator9.1 build analyze
+  - xctool -project Project/Player.xcodeproj -scheme 'Debug - iOS' -sdk iphonesimulator9.3 build analyze
+#  - xctool -project Project/Player.xcodeproj -scheme 'Debug - tvOS' -sdk appletvsimulator9.2 build analyze

--- a/Project/Player/ViewController.swift
+++ b/Project/Player/ViewController.swift
@@ -65,7 +65,7 @@ class ViewController: UIViewController, PlayerDelegate {
         
         self.player.playbackLoops = true
         
-        let tapGestureRecognizer: UITapGestureRecognizer = UITapGestureRecognizer(target: self, action: "handleTapGestureRecognizer:")
+        let tapGestureRecognizer: UITapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(handleTapGestureRecognizer(_:)))
         tapGestureRecognizer.numberOfTapsRequired = 1
         self.player.view.addGestureRecognizer(tapGestureRecognizer)
     }

--- a/Sources/Player.swift
+++ b/Sources/Player.swift
@@ -242,8 +242,9 @@ public class Player: UIViewController {
         self.view = self.playerView
         self.playerView.layer.addObserver(self, forKeyPath: PlayerReadyForDisplay, options: ([NSKeyValueObservingOptions.New, NSKeyValueObservingOptions.Old]), context: &PlayerLayerObserverContext)
 
-        NSNotificationCenter.defaultCenter().addObserver(self, selector: "applicationWillResignActive:", name: UIApplicationWillResignActiveNotification, object: UIApplication.sharedApplication())
-        NSNotificationCenter.defaultCenter().addObserver(self, selector: "applicationDidEnterBackground:", name: UIApplicationDidEnterBackgroundNotification, object: UIApplication.sharedApplication())
+        NSNotificationCenter.defaultCenter().addObserver(self, selector: #selector(applicationWillResignActive(_:)), name: UIApplicationWillResignActiveNotification, object: UIApplication.sharedApplication())
+        NSNotificationCenter.defaultCenter().addObserver(self, selector: #selector(applicationDidEnterBackground(_:)), name: UIApplicationDidEnterBackgroundNotification, object: UIApplication.sharedApplication())
+        NSNotificationCenter.defaultCenter().addObserver(self, selector: #selector(applicationWillEnterForeground(_:)), name: UIApplicationWillEnterForegroundNotification, object: UIApplication.sharedApplication())
     }
 
     public override func viewDidDisappear(animated: Bool) {
@@ -355,8 +356,8 @@ public class Player: UIViewController {
             self.playerItem?.addObserver(self, forKeyPath: PlayerKeepUp, options: ([NSKeyValueObservingOptions.New, NSKeyValueObservingOptions.Old]), context: &PlayerItemObserverContext)
             self.playerItem?.addObserver(self, forKeyPath: PlayerStatusKey, options: ([NSKeyValueObservingOptions.New, NSKeyValueObservingOptions.Old]), context: &PlayerItemObserverContext)
 
-            NSNotificationCenter.defaultCenter().addObserver(self, selector: "playerItemDidPlayToEndTime:", name: AVPlayerItemDidPlayToEndTimeNotification, object: self.playerItem)
-            NSNotificationCenter.defaultCenter().addObserver(self, selector: "playerItemFailedToPlayToEndTime:", name: AVPlayerItemFailedToPlayToEndTimeNotification, object: self.playerItem)
+          NSNotificationCenter.defaultCenter().addObserver(self, selector: #selector(playerItemDidPlayToEndTime(_:)), name: AVPlayerItemDidPlayToEndTimeNotification, object: self.playerItem)
+          NSNotificationCenter.defaultCenter().addObserver(self, selector: #selector(playerItemFailedToPlayToEndTime(_:)), name: AVPlayerItemFailedToPlayToEndTimeNotification, object: self.playerItem)
         }
 
         self.player.replaceCurrentItemWithPlayerItem(self.playerItem)
@@ -394,6 +395,12 @@ public class Player: UIViewController {
     public func applicationDidEnterBackground(aNotification: NSNotification) {
         if self.playbackState == .Playing {
             self.pause()
+        }
+    }
+  
+    public func applicationWillEnterForeground(aNoticiation: NSNotification) {
+        if self.playbackState == .Stopped || self.playbackState == .Paused {
+            self.player.play()
         }
     }
 


### PR DESCRIPTION
1. Removed selector warnings in Xcode 7.3. e.g. "Use of string literal for Objective-C is deprecated..."
2. Fixes bug #31, made the player resumes playing when view is re-visible.