### PR TITLE
Application will enter foreground bug

### DIFF
--- a/Sources/Player.swift
+++ b/Sources/Player.swift
@@ -405,7 +405,7 @@ public class Player: UIViewController {
   
     public func applicationWillEnterForeground(aNoticiation: NSNotification) {
         if self.playbackState == .Paused {
-            self.player.play()
+            self.playFromCurrentTime()
         }
     }
 


### PR DESCRIPTION
When application will enter foreground video starts playing but
delegate method "playerPlaybackStateDidChange" wasn't called.