### PR TITLE
move PlayerDelegate method to value observer `didSet`.

### DIFF
--- a/Sources/Player.swift
+++ b/Sources/Player.swift
@@ -156,12 +156,16 @@ public class Player: UIViewController {
     public var playbackFreezesAtEnd: Bool! = false
     public var playbackState: PlaybackState! = .Stopped {
         didSet {
-            self.delegate?.playerPlaybackStateDidChange(self)
+            if playbackState != oldValue {
+                self.delegate?.playerPlaybackStateDidChange(self)
+            }
         }
     }
     public var bufferingState: BufferingState! = .Unknown {
         didSet {
-            self.delegate?.playerBufferingStateDidChange(self)
+            if bufferingState != oldValue {
+                self.delegate?.playerBufferingStateDidChange(self)
+            }
         }
     }
 
@@ -229,9 +233,6 @@ public class Player: UIViewController {
         }
 
         self.playbackLoops = false
-//        self.playbackFreezesAtEnd = false
-//        self.playbackState = .Stopped
-//        self.bufferingState = .Unknown
     }
 
     deinit {
@@ -282,7 +283,6 @@ public class Player: UIViewController {
 
     public func playFromCurrentTime() {
         self.playbackState = .Playing
-//        self.delegate?.playerPlaybackStateDidChange(self)
         self.player.play()
     }
 
@@ -293,7 +293,6 @@ public class Player: UIViewController {
 
         self.player.pause()
         self.playbackState = .Paused
-//        self.delegate?.playerPlaybackStateDidChange(self)
     }
 
     public func stop() {
@@ -303,7 +302,6 @@ public class Player: UIViewController {
 
         self.player.pause()
         self.playbackState = .Stopped
-//        self.delegate?.playerPlaybackStateDidChange(self)
         self.delegate?.playerPlaybackDidEnd(self)
     }
     
@@ -321,7 +319,6 @@ public class Player: UIViewController {
         }
 
         self.bufferingState = .Unknown
-//        self.delegate?.playerBufferingStateDidChange(self)
 
         self.asset = asset
         if let _ = self.asset {
@@ -338,14 +335,12 @@ public class Player: UIViewController {
                     let status = self.asset.statusOfValueForKey(key, error:&error)
                     if status == .Failed {
                         self.playbackState = .Failed
-//                        self.delegate?.playerPlaybackStateDidChange(self)
                         return
                     }
                 }
 
                 if self.asset.playable.boolValue == false {
                     self.playbackState = .Failed
-//                    self.delegate?.playerPlaybackStateDidChange(self)
                     return
                 }
 
@@ -405,7 +400,6 @@ public class Player: UIViewController {
 
     public func playerItemFailedToPlayToEndTime(aNotification: NSNotification) {
         self.playbackState = .Failed
-//        self.delegate?.playerPlaybackStateDidChange(self)
     }
 
     public func applicationWillResignActive(aNotification: NSNotification) {
@@ -438,7 +432,6 @@ public class Player: UIViewController {
         case (.Some(PlayerKeepUp), &PlayerItemObserverContext):
             if let item = self.playerItem {
                 self.bufferingState = .Ready
-//                self.delegate?.playerBufferingStateDidChange(self)
 
                 if item.playbackLikelyToKeepUp && self.playbackState == .Playing {
                     self.playFromCurrentTime()
@@ -453,7 +446,6 @@ public class Player: UIViewController {
                 self.playerView.playerLayer.hidden = false
             case AVPlayerStatus.Failed.rawValue:
                 self.playbackState = PlaybackState.Failed
-//                self.delegate?.playerPlaybackStateDidChange(self)
             default:
                 true
             }
@@ -461,7 +453,6 @@ public class Player: UIViewController {
             if let item = self.playerItem {
                 if item.playbackBufferEmpty {
                     self.bufferingState = .Delayed
-//                    self.delegate?.playerBufferingStateDidChange(self)
                 }
             }
 
@@ -473,7 +464,6 @@ public class Player: UIViewController {
                 self.playerView.playerLayer.hidden = false
             case AVPlayerStatus.Failed.rawValue:
                 self.playbackState = PlaybackState.Failed
-//                self.delegate?.playerPlaybackStateDidChange(self)
             default:
                 true
             }

--- a/Sources/Player.swift
+++ b/Sources/Player.swift
@@ -155,7 +155,7 @@ public class Player: UIViewController {
         }
     }
     
-    public var playbackFreezesAtEnd: Bool! = false
+    public var playbackFreezesAtEnd: Bool!
     
     public var playbackState: PlaybackState! = .Stopped {
         didSet {
@@ -240,6 +240,7 @@ public class Player: UIViewController {
         }
 
         self.playbackLoops = false
+        self.playbackFreezesAtEnd = false
     }
 
     deinit {

--- a/Sources/Player.swift
+++ b/Sources/Player.swift
@@ -153,17 +153,18 @@ public class Player: UIViewController {
             }
         }
     }
+    public var playbackEdgeTriggered: Bool! = true
     public var playbackFreezesAtEnd: Bool! = false
     public var playbackState: PlaybackState! = .Stopped {
         didSet {
-            if playbackState != oldValue {
+            if playbackState != oldValue || !playbackEdgeTriggered {
                 self.delegate?.playerPlaybackStateDidChange(self)
             }
         }
     }
     public var bufferingState: BufferingState! = .Unknown {
         didSet {
-            if bufferingState != oldValue {
+            if bufferingState != oldValue || !playbackEdgeTriggered {
                 self.delegate?.playerBufferingStateDidChange(self)
             }
         }
@@ -442,7 +443,7 @@ public class Player: UIViewController {
 
             switch (status) {
             case AVPlayerStatus.ReadyToPlay.rawValue:
-                self.playerView.playerLayer.player = self.player
+                self.playerView.player = self.player
                 self.playerView.playerLayer.hidden = false
             case AVPlayerStatus.Failed.rawValue:
                 self.playbackState = PlaybackState.Failed
@@ -496,7 +497,9 @@ internal class PlayerView: UIView {
             return (self.layer as! AVPlayerLayer).player
         }
         set {
-            (self.layer as! AVPlayerLayer).player = newValue
+            if (self.layer as! AVPlayerLayer).player != newValue {
+                (self.layer as! AVPlayerLayer).player = newValue
+            }
         }
     }
 

--- a/Sources/Player.swift
+++ b/Sources/Player.swift
@@ -153,9 +153,17 @@ public class Player: UIViewController {
             }
         }
     }
-    public var playbackFreezesAtEnd: Bool!
-    public var playbackState: PlaybackState!
-    public var bufferingState: BufferingState!
+    public var playbackFreezesAtEnd: Bool! = false
+    public var playbackState: PlaybackState! = .Stopped {
+        didSet {
+            self.delegate?.playerPlaybackStateDidChange(self)
+        }
+    }
+    public var bufferingState: BufferingState! = .Unknown {
+        didSet {
+            self.delegate?.playerBufferingStateDidChange(self)
+        }
+    }
 
     public var maximumDuration: NSTimeInterval! {
         get {
@@ -221,9 +229,9 @@ public class Player: UIViewController {
         }
 
         self.playbackLoops = false
-        self.playbackFreezesAtEnd = false
-        self.playbackState = .Stopped
-        self.bufferingState = .Unknown
+//        self.playbackFreezesAtEnd = false
+//        self.playbackState = .Stopped
+//        self.bufferingState = .Unknown
     }
 
     deinit {
@@ -274,7 +282,7 @@ public class Player: UIViewController {
 
     public func playFromCurrentTime() {
         self.playbackState = .Playing
-        self.delegate?.playerPlaybackStateDidChange(self)
+//        self.delegate?.playerPlaybackStateDidChange(self)
         self.player.play()
     }
 
@@ -285,7 +293,7 @@ public class Player: UIViewController {
 
         self.player.pause()
         self.playbackState = .Paused
-        self.delegate?.playerPlaybackStateDidChange(self)
+//        self.delegate?.playerPlaybackStateDidChange(self)
     }
 
     public func stop() {
@@ -295,7 +303,7 @@ public class Player: UIViewController {
 
         self.player.pause()
         self.playbackState = .Stopped
-        self.delegate?.playerPlaybackStateDidChange(self)
+//        self.delegate?.playerPlaybackStateDidChange(self)
         self.delegate?.playerPlaybackDidEnd(self)
     }
     
@@ -313,7 +321,7 @@ public class Player: UIViewController {
         }
 
         self.bufferingState = .Unknown
-        self.delegate?.playerBufferingStateDidChange(self)
+//        self.delegate?.playerBufferingStateDidChange(self)
 
         self.asset = asset
         if let _ = self.asset {
@@ -330,14 +338,14 @@ public class Player: UIViewController {
                     let status = self.asset.statusOfValueForKey(key, error:&error)
                     if status == .Failed {
                         self.playbackState = .Failed
-                        self.delegate?.playerPlaybackStateDidChange(self)
+//                        self.delegate?.playerPlaybackStateDidChange(self)
                         return
                     }
                 }
 
                 if self.asset.playable.boolValue == false {
                     self.playbackState = .Failed
-                    self.delegate?.playerPlaybackStateDidChange(self)
+//                    self.delegate?.playerPlaybackStateDidChange(self)
                     return
                 }
 
@@ -397,7 +405,7 @@ public class Player: UIViewController {
 
     public func playerItemFailedToPlayToEndTime(aNotification: NSNotification) {
         self.playbackState = .Failed
-        self.delegate?.playerPlaybackStateDidChange(self)
+//        self.delegate?.playerPlaybackStateDidChange(self)
     }
 
     public func applicationWillResignActive(aNotification: NSNotification) {
@@ -430,7 +438,7 @@ public class Player: UIViewController {
         case (.Some(PlayerKeepUp), &PlayerItemObserverContext):
             if let item = self.playerItem {
                 self.bufferingState = .Ready
-                self.delegate?.playerBufferingStateDidChange(self)
+//                self.delegate?.playerBufferingStateDidChange(self)
 
                 if item.playbackLikelyToKeepUp && self.playbackState == .Playing {
                     self.playFromCurrentTime()
@@ -445,7 +453,7 @@ public class Player: UIViewController {
                 self.playerView.playerLayer.hidden = false
             case AVPlayerStatus.Failed.rawValue:
                 self.playbackState = PlaybackState.Failed
-                self.delegate?.playerPlaybackStateDidChange(self)
+//                self.delegate?.playerPlaybackStateDidChange(self)
             default:
                 true
             }
@@ -453,7 +461,7 @@ public class Player: UIViewController {
             if let item = self.playerItem {
                 if item.playbackBufferEmpty {
                     self.bufferingState = .Delayed
-                    self.delegate?.playerBufferingStateDidChange(self)
+//                    self.delegate?.playerBufferingStateDidChange(self)
                 }
             }
 
@@ -465,7 +473,7 @@ public class Player: UIViewController {
                 self.playerView.playerLayer.hidden = false
             case AVPlayerStatus.Failed.rawValue:
                 self.playbackState = PlaybackState.Failed
-                self.delegate?.playerPlaybackStateDidChange(self)
+//                self.delegate?.playerPlaybackStateDidChange(self)
             default:
                 true
             }


### PR DESCRIPTION
1. move PlayerDelegate method to value observer `didSet`.

2. Add `playbackEdgeTriggered ` that indicate whether `self.delegate?.playerBufferingStateDidChange(self)` and ` self.delegate?.playerPlaybackStateDidChange(self)` should be called when `bufferingState ` and `playbackState` is set (the value may not be changed) or just set when the value is changed.
