### PR TITLE
fix crash while resolving timeRange

### DIFF
--- a/Sources/Player.swift
+++ b/Sources/Player.swift
@@ -513,8 +513,8 @@ extension Player {
                 if let item = self.playerItem {
                     self.bufferingState = .ready
                     
-                    let timeRanges = (change?[NSKeyValueChangeKey.newKey] as! [CMTimeRange])
-                    let timeRange: CMTimeRange = timeRanges[0] as CMTimeRange
+                    let timeRanges = item.loadedTimeRanges
+                    let timeRange: CMTimeRange = timeRanges[0].timeRangeValue
                     let bufferedTime = CMTimeGetSeconds(CMTimeAdd(timeRange.start, timeRange.duration))
                     let currentTime = CMTimeGetSeconds(item.currentTime())
                     


### PR DESCRIPTION
It seems change?[NSKeyValueChangeKey.newKey] cannot be casted as [CMTimeRange] with Xcode 8.0 beta6.