### PR TITLE
Convert Player class from `public` to `open` for subclassing.

### DIFF
--- a/Player.podspec
+++ b/Player.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = 'Player'
-  s.version = '0.2.0'
+  s.version = '0.2.0.1'
   s.license = 'MIT'
   s.summary = 'video player in Swift, simple way to play and stream media in your iOS or tvOS app'
   s.homepage = 'https://github.com/piemonte/player'

--- a/Sources/Player.swift
+++ b/Sources/Player.swift
@@ -248,14 +248,14 @@ open class Player: UIViewController {
 
     // MARK: - view lifecycle
 
-    public override func loadView() {
+    open override func loadView() {
         self.playerView = PlayerView(frame: CGRect.zero)
         self.playerView.fillMode = AVLayerVideoGravityResizeAspect
         self.playerView.playerLayer.isHidden = true
         self.view = self.playerView
     }
     
-    public override func viewDidLoad() {
+    open override func viewDidLoad() {
         super.viewDidLoad()
         
         self.playerView.layer.addObserver(self, forKeyPath: PlayerReadyForDisplayKey, options: ([.new, .old]), context: &PlayerLayerObserverContext)
@@ -269,7 +269,7 @@ open class Player: UIViewController {
         self.addApplicationObservers();
     }
 
-    public override func viewDidDisappear(_ animated: Bool) {
+    open override func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
 
         if self.playbackState == .playing {
@@ -476,7 +476,7 @@ private let PlayerReadyForDisplayKey = "readyForDisplay"
 
 extension Player {
     
-    override public func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey : Any]?, context: UnsafeMutableRawPointer?) {
+    override open func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey : Any]?, context: UnsafeMutableRawPointer?) {
 
         // PlayerRateKey, PlayerObserverContext
         

--- a/Sources/Player.swift
+++ b/Sources/Player.swift
@@ -88,7 +88,7 @@ public enum BufferingState: Int, CustomStringConvertible {
 
 // MARK: - Player
 
-public class Player: UIViewController {
+open class Player: UIViewController {
 
     public weak var delegate: PlayerDelegate?
 


### PR DESCRIPTION
Since Player is a UIViewController, it is sometimes required to subclass, especially for purposes of adding a controls layer.

These controls needs to be stored as members in the view controller, so `extension` wouldn't work, we need to be able to inherit from Player.