### PR TITLE
Allow setting up Player from local AVAsset

### DIFF
--- a/Sources/Player.swift
+++ b/Sources/Player.swift
@@ -125,6 +125,26 @@ open class Player: UIViewController {
         }
     }
 
+    /// For setting up with AVAsset instead of URL
+    /// Note: Resets URL (cannot set both)
+    open var asset: AVAsset? {
+        didSet {
+            url = nil
+            guard isViewLoaded else { return }
+
+            // ensure everything is reset beforehand
+            if self.playbackState == .playing {
+                self.pause()
+            }
+
+            self.setupPlayerItem(nil)
+
+            if let asset = asset {
+                self.setupAsset(asset)
+            }
+        }
+    }
+
     /// Mutes audio playback when true.
     open var muted: Bool {
         get {
@@ -307,8 +327,12 @@ open class Player: UIViewController {
     
     open override func viewDidLoad() {
         super.viewDidLoad()
-        
-        setup(url: url)
+
+        if self.url != nil {
+            setup(url: url)
+        } else if let asset = self.asset {
+            setupAsset(asset)
+        }
         
         self.addPlayerLayerObservers();
         self.addPlayerObservers();
@@ -441,7 +465,7 @@ extension Player {
         let keys: [String] = [PlayerTracksKey, PlayerPlayableKey, PlayerDurationKey]
 
         self._asset.loadValuesAsynchronously(forKeys: keys, completionHandler: { () -> Void in
-            DispatchQueue.main.sync(execute: { () -> Void in
+            DispatchQueue.main.async(execute: { () -> Void in
 
                 for key in keys {
                     var error: NSError?

--- a/Sources/Player.swift
+++ b/Sources/Player.swift
@@ -132,13 +132,6 @@ open class Player: UIViewController {
             url = nil
             guard isViewLoaded else { return }
 
-            // ensure everything is reset beforehand
-            if self.playbackState == .playing {
-                self.pause()
-            }
-
-            self.setupPlayerItem(nil)
-
             if let asset = asset {
                 self.setupAsset(asset)
             }


### PR DESCRIPTION
We have an AVAsset from our capture tool. It seems silly to write it to a file just to play it so we made a slight modification to allow setting up the player using the premade Asset.

Would love to get your feedback!