### PR TITLE
Autoplay Flag

### DIFF
--- a/Sources/Player.swift
+++ b/Sources/Player.swift
@@ -141,6 +141,11 @@ open class Player: UIViewController {
             setup(url: url)
         }
     }
+    
+    /// Determines if the video should autoplay when a url is set
+    ///
+    /// - Parameter bool: defaults to true
+    open var autoplay: Bool = true
 
     /// Mutes audio playback when true.
     open var muted: Bool {

--- a/Sources/Player.swift
+++ b/Sources/Player.swift
@@ -286,6 +286,11 @@ open class Player: UIViewController {
     internal var _playerView: PlayerView = PlayerView(frame: .zero)
     internal var _seekTimeRequested: CMTime?
     
+    internal var _lastBufferTime:Double = 0
+    
+    //Boolean that determines if the user or calling coded has trigged autoplay manually.
+    internal var _hasAutoplayActivated : Bool = true
+    
     // MARK: - object lifecycle
 
     public convenience init() {
@@ -359,8 +364,18 @@ open class Player: UIViewController {
 
     /// Begins playback of the media from the current time.
     open func playFromCurrentTime() {
-        self.playbackState = .playing
-        self._avplayer.play()
+        if !autoplay{
+            //external call to this method with auto play off.  activate it before calling play
+            _hasAutoplayActivated = true
+        }
+        play()
+    }
+    
+    fileprivate func play(){
+        if autoplay || _hasAutoplayActivated{
+            self.playbackState = .playing
+            self._avplayer.play()
+        }
     }
 
     /// Pauses playback of the media.
@@ -452,6 +467,14 @@ extension Player {
             self.pause()
         }
         
+        //Reset autoplay flag since a new url is set.
+        _hasAutoplayActivated = false
+        if autoplay {
+            playbackState = .playing
+        }else{
+            playbackState = .stopped
+        }
+        
         self.setupPlayerItem(nil)
         
         if let url = url {
@@ -461,9 +484,6 @@ extension Player {
     }
 
     fileprivate func setupAsset(_ asset: AVAsset) {
-        if self.playbackState == .playing {
-            self.pause()
-        }
 
         self.bufferingState = .unknown
 
@@ -585,7 +605,7 @@ extension Player {
   
     internal func handleApplicationWillEnterForeground(_ aNoticiation: Notification) {
         if self.playbackState != .playing && self.playbackResumesWhenEnteringForeground {
-            self.playFromCurrentTime()
+            self.play()
         }
     }
 
@@ -667,7 +687,7 @@ extension Player {
                     self.bufferingState = .ready
                     
                     if item.isPlaybackLikelyToKeepUp && self.playbackState == .playing {
-                        self.playFromCurrentTime()
+                        self.play()
                     }
                 }
                 
@@ -719,16 +739,23 @@ extension Player {
                     let timeRanges = item.loadedTimeRanges
                     if let timeRange = timeRanges.first?.timeRangeValue {
                         let bufferedTime = CMTimeGetSeconds(CMTimeAdd(timeRange.start, timeRange.duration))
-                        self.executeClosureOnMainQueueIfNecessary {
-                            self.playerDelegate?.playerBufferTimeDidChange(bufferedTime)
+                        if _lastBufferTime != bufferedTime{
+                            self.executeClosureOnMainQueueIfNecessary {
+                                self.playerDelegate?.playerBufferTimeDidChange(bufferedTime)
+                            }
+                            _lastBufferTime = bufferedTime
                         }
-                        let currentTime = CMTimeGetSeconds(item.currentTime())
-                        if (bufferedTime - currentTime) >= self.bufferSize && self.playbackState == .playing {
-                            self.playFromCurrentTime()
-                        }
-                    } else {
-                        self.playFromCurrentTime()
                     }
+                    
+                    let currentTime = CMTimeGetSeconds(item.currentTime())
+                    if ((_lastBufferTime - currentTime) >= self.bufferSize ||
+                        _lastBufferTime == maximumDuration ||
+                        timeRanges.first == nil)
+                        && self.playbackState == .playing
+                        {
+                        self.play()
+                    }
+                    
                 }
                 
             }


### PR DESCRIPTION
This PR adds an autoplay flag defaulting to true that allows implementation to determine if a video should auto play when a url is set.

This change I made locally in my project because I wasn't sure whether videos should start playing automatically or not when I set a url.  When my url was streaming, the video would auto play upon setting the url.  However, when my video was a local video, it would not auto play.  The goal of this PR is correct that behavior.  Since I wasn't sure which was it should be, I went ahead and added an autoplay flag.

The reason the auto play was not consistent before this change, had to do with logic in the PlayerLoadedTimeRangesKey observable if block - either playing or not playing the video not consistent with setting a url.