### PR TITLE
Avoid overwriting fill mode when loadView

### DIFF
--- a/Sources/Player.swift
+++ b/Sources/Player.swift
@@ -342,7 +342,6 @@ open class Player: UIViewController {
     // MARK: - view lifecycle
 
     open override func loadView() {
-        self._playerView.fillMode = PlayerFillMode.resizeAspectFit.avFoundationType
         self._playerView.playerLayer.isHidden = true
         self.view = self._playerView
     }


### PR DESCRIPTION
I think this line is unnecessary. Please check it out.
```swift
self.player = Player()
self.player.fillMode = PlayerFillMode.resizeAspectFill.avFoundationType // I set `fillMode` here
self.player.view.frame = self.view.bounds
 
self.addChildViewController(self.player)
self.view.addSubview(self.player.view)
// `loadView` is called and `fillMode` is overwritten 😥
self.player.didMoveToParentViewController(self)
```