### PR TITLE
Refactor: remove semicolon, remove unnecesary parenthesis, etc.

### DIFF
--- a/Sources/Player.swift
+++ b/Sources/Player.swift
@@ -196,10 +196,10 @@ open class Player: UIViewController {
     /// Playback automatically loops continuously when true.
     open var playbackLoops: Bool {
         get {
-            return (self._avplayer.actionAtItemEnd == .none) as Bool
+            return self._avplayer.actionAtItemEnd == .none
         }
         set {
-            if newValue == true {
+            if newValue {
                 self._avplayer.actionAtItemEnd = .none
             } else {
                 self._avplayer.actionAtItemEnd = .pause
@@ -298,10 +298,10 @@ open class Player: UIViewController {
     internal var _playerView: PlayerView = PlayerView(frame: .zero)
     internal var _seekTimeRequested: CMTime?
     
-    internal var _lastBufferTime:Double = 0
+    internal var _lastBufferTime: Double = 0
     
     //Boolean that determines if the user or calling coded has trigged autoplay manually.
-    internal var _hasAutoplayActivated : Bool = true
+    internal var _hasAutoplayActivated: Bool = true
     
     // MARK: - object lifecycle
 
@@ -355,9 +355,9 @@ open class Player: UIViewController {
             setupAsset(asset)
         }
         
-        self.addPlayerLayerObservers();
-        self.addPlayerObservers();
-        self.addApplicationObservers();
+        self.addPlayerLayerObservers()
+        self.addPlayerObservers()
+        self.addApplicationObservers()
     }
 
     open override func viewDidDisappear(_ animated: Bool) {
@@ -379,15 +379,15 @@ open class Player: UIViewController {
 
     /// Begins playback of the media from the current time.
     open func playFromCurrentTime() {
-        if !autoplay{
+        if !autoplay {
             //external call to this method with auto play off.  activate it before calling play
             _hasAutoplayActivated = true
         }
         play()
     }
     
-    fileprivate func play(){
-        if autoplay || _hasAutoplayActivated{
+    fileprivate func play() {
+        if autoplay || _hasAutoplayActivated {
             self.playbackState = .playing
             self._avplayer.play()
         }
@@ -420,7 +420,7 @@ open class Player: UIViewController {
     open func seek(to time: CMTime) {
         if let playerItem = self._playerItem {
             return playerItem.seek(to: time)
-        }else{
+        } else {
             _seekTimeRequested = time
         }
     }
@@ -430,12 +430,12 @@ open class Player: UIViewController {
     /// - Parameters:
     ///   - time: The time to switch to move the playback.
     ///   - completionHandler: call block handler after seeking
-    open func seek(to time: CMTime , completionHandler: @escaping () -> Swift.Void) {
-        if let playerItem =  self._playerItem {
+    open func seek(to time: CMTime, completionHandler: @escaping () -> Void) {
+        if let playerItem = self._playerItem {
             return playerItem.seek(to: time, completionHandler: { (seeked) in
                 completionHandler()
             })
-        }else{
+        } else {
             _seekTimeRequested = time
         }
     }
@@ -486,7 +486,7 @@ extension Player {
         _hasAutoplayActivated = false
         if autoplay {
             playbackState = .playing
-        }else{
+        } else {
             playbackState = .stopped
         }
         
@@ -521,12 +521,12 @@ extension Player {
             }
 
             if let asset = self._asset {
-                if asset.isPlayable == false {
+                if !asset.isPlayable {
                     self.playbackState = .failed
                     return
                 }
                 
-                let playerItem: AVPlayerItem = AVPlayerItem(asset:asset)
+                let playerItem = AVPlayerItem(asset:asset)
                 self.setupPlayerItem(playerItem)
             }
         })
@@ -545,15 +545,15 @@ extension Player {
 
         self._playerItem = playerItem
 
-        if let seek = _seekTimeRequested, self._playerItem != nil{
+        if let seek = _seekTimeRequested, self._playerItem != nil {
             _seekTimeRequested = nil
             self.seek(to: seek)
         }
 
-        self._playerItem?.addObserver(self, forKeyPath: PlayerEmptyBufferKey, options: ([.new, .old]), context: &PlayerItemObserverContext)
-        self._playerItem?.addObserver(self, forKeyPath: PlayerKeepUpKey, options: ([.new, .old]), context: &PlayerItemObserverContext)
-        self._playerItem?.addObserver(self, forKeyPath: PlayerStatusKey, options: ([.new, .old]), context: &PlayerItemObserverContext)
-        self._playerItem?.addObserver(self, forKeyPath: PlayerLoadedTimeRangesKey, options: ([.new, .old]), context: &PlayerItemObserverContext)
+        self._playerItem?.addObserver(self, forKeyPath: PlayerEmptyBufferKey, options: [.new, .old], context: &PlayerItemObserverContext)
+        self._playerItem?.addObserver(self, forKeyPath: PlayerKeepUpKey, options: [.new, .old], context: &PlayerItemObserverContext)
+        self._playerItem?.addObserver(self, forKeyPath: PlayerStatusKey, options: [.new, .old], context: &PlayerItemObserverContext)
+        self._playerItem?.addObserver(self, forKeyPath: PlayerLoadedTimeRangesKey, options: [.new, .old], context: &PlayerItemObserverContext)
 
         if let updatedPlayerItem = self._playerItem {
             NotificationCenter.default.addObserver(self, selector: #selector(playerItemDidPlayToEndTime(_:)), name: .AVPlayerItemDidPlayToEndTime, object: updatedPlayerItem)
@@ -563,7 +563,7 @@ extension Player {
         self._avplayer.replaceCurrentItem(with: self._playerItem)
         
         // update new playerItem settings
-        if self.playbackLoops == true {
+        if self.playbackLoops {
             self._avplayer.actionAtItemEnd = .none
         } else {
             self._avplayer.actionAtItemEnd = .pause
@@ -579,11 +579,11 @@ extension Player {
     // MARK: - AVPlayerItem
     
     @objc internal func playerItemDidPlayToEndTime(_ aNotification: Notification) {
-        if self.playbackLoops == true {
+        if self.playbackLoops {
             self.playbackDelegate?.playerPlaybackWillLoop(self)
             self._avplayer.seek(to: kCMTimeZero)
         } else {
-            if self.playbackFreezesAtEnd == true {
+            if self.playbackFreezesAtEnd {
                 self.stop()
             } else {
                 self._avplayer.seek(to: kCMTimeZero, completionHandler: { _ in
@@ -662,7 +662,7 @@ extension Player {
     // MARK: - AVPlayerLayerObservers
     
     internal func addPlayerLayerObservers() {
-        self._playerView.layer.addObserver(self, forKeyPath: PlayerReadyForDisplayKey, options: ([.new, .old]), context: &PlayerLayerObserverContext)
+        self._playerView.layer.addObserver(self, forKeyPath: PlayerReadyForDisplayKey, options: [.new, .old], context: &PlayerLayerObserverContext)
     }
     
     internal func removePlayerLayerObservers() {
@@ -672,14 +672,14 @@ extension Player {
     // MARK: - AVPlayerObservers
     
     internal func addPlayerObservers() {
-        self._timeObserver = self._avplayer.addPeriodicTimeObserver(forInterval: CMTimeMake(1,100), queue: DispatchQueue.main, using: { [weak self] timeInterval in
+        self._timeObserver = self._avplayer.addPeriodicTimeObserver(forInterval: CMTimeMake(1, 100), queue: DispatchQueue.main, using: { [weak self] timeInterval in
             guard let strongSelf = self
             else {
                 return
             }
             strongSelf.playbackDelegate?.playerCurrentTimeDidChange(strongSelf)
         })
-        self._avplayer.addObserver(self, forKeyPath: PlayerRateKey, options: ([.new, .old]) , context: &PlayerObserverContext)
+        self._avplayer.addObserver(self, forKeyPath: PlayerRateKey, options: [.new, .old], context: &PlayerObserverContext)
     }
     
     internal func removePlayerObservers() {
@@ -691,11 +691,11 @@ extension Player {
     
     // MARK: -
     
-    override open func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey : Any]?, context: UnsafeMutableRawPointer?) {
+    override open func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey: Any]?, context: UnsafeMutableRawPointer?) {
 
         // PlayerRateKey, PlayerObserverContext
         
-        if (context == &PlayerItemObserverContext) {
+        if context == &PlayerItemObserverContext {
             
             // PlayerStatusKey
             
@@ -707,21 +707,19 @@ extension Player {
 
                   if item.isPlaybackLikelyToKeepUp {
                         self.bufferingState = .ready
-                        if self.playbackState == .playing{
+                        if self.playbackState == .playing {
                             self.playFromCurrentTime()
                         }
                     }
                 }
                 
                 if let status = change?[NSKeyValueChangeKey.newKey] as? NSNumber {
-                    switch (status.intValue as AVPlayerStatus.RawValue) {
+                    switch status.intValue as AVPlayerStatus.RawValue {
                     case AVPlayerStatus.readyToPlay.rawValue:
                         self._playerView.playerLayer.player = self._avplayer
                         self._playerView.playerLayer.isHidden = false
-                        break
                     case AVPlayerStatus.failed.rawValue:
                         self.playbackState = PlaybackState.failed
-                        break
                     default:
                         break
                     }
@@ -738,14 +736,12 @@ extension Player {
                 }
                 
                 if let status = change?[NSKeyValueChangeKey.newKey] as? NSNumber {
-                    switch (status.intValue as AVPlayerStatus.RawValue) {
+                    switch status.intValue as AVPlayerStatus.RawValue {
                     case AVPlayerStatus.readyToPlay.rawValue:
                         self._playerView.playerLayer.player = self._avplayer
                         self._playerView.playerLayer.isHidden = false
-                        break
                     case AVPlayerStatus.failed.rawValue:
                         self.playbackState = PlaybackState.failed
-                        break
                     default:
                         break
                     }
@@ -761,7 +757,7 @@ extension Player {
                     let timeRanges = item.loadedTimeRanges
                     if let timeRange = timeRanges.first?.timeRangeValue {
                         let bufferedTime = CMTimeGetSeconds(CMTimeAdd(timeRange.start, timeRange.duration))
-                        if _lastBufferTime != bufferedTime{
+                        if _lastBufferTime != bufferedTime {
                             self.executeClosureOnMainQueueIfNecessary {
                                 self.playerDelegate?.playerBufferTimeDidChange(bufferedTime)
                             }
@@ -782,7 +778,7 @@ extension Player {
                 
             }
         
-        } else if (context == &PlayerLayerObserverContext) {
+        } else if context == &PlayerLayerObserverContext {
             if self._playerView.playerLayer.isReadyForDisplay {
                 self.executeClosureOnMainQueueIfNecessary {
                     self.playerDelegate?.playerReady(self)
@@ -814,7 +810,7 @@ internal class PlayerView: UIView {
 
     // MARK: - properties
     
-    override class var layerClass: Swift.AnyClass {
+    override class var layerClass: AnyClass {
         get {
             return AVPlayerLayer.self
         }


### PR DESCRIPTION
Hello😸

I refactored `Player.swift` as follows.
- Remove semicolons
- Remove unnecessary parenthesis
- Add a space after a colon
- Remove spaces before a colon or comma
- Add a space before a `{`
- Remove unnecessary `break` on `switch-case`
- Remove `Swift.` of `Swift.Void` and `Swift.AnyClass`
- Remove `== true` on `if`
- Replace `if hoge == false {` to `if !hoge {`

Please review🙇