### PR TITLE
Solve issue#166 and 'playbackPausesWhenBackgrounded' doesn't work well.

### DIFF
--- a/Sources/Player.swift
+++ b/Sources/Player.swift
@@ -191,6 +191,9 @@ open class Player: UIViewController {
     /// Pauses playback automatically when backgrounded.
     open var playbackPausesWhenBackgrounded: Bool = true
     
+    /// Resumes playback when became active.
+    open var playbackResumesWhenBecameActive: Bool = true
+
     /// Resumes playback when entering foreground.
     open var playbackResumesWhenEnteringForeground: Bool = true
     
@@ -604,6 +607,7 @@ extension Player {
     
     internal func addApplicationObservers() {
         NotificationCenter.default.addObserver(self, selector: #selector(handleApplicationWillResignActive(_:)), name: .UIApplicationWillResignActive, object: UIApplication.shared)
+        NotificationCenter.default.addObserver(self, selector: #selector(handleApplicationDidBecomeActive(_:)), name: .UIApplicationDidBecomeActive, object: UIApplication.shared)
         NotificationCenter.default.addObserver(self, selector: #selector(handleApplicationDidEnterBackground(_:)), name: .UIApplicationDidEnterBackground, object: UIApplication.shared)
         NotificationCenter.default.addObserver(self, selector: #selector(handleApplicationWillEnterForeground(_:)), name: .UIApplicationWillEnterForeground, object: UIApplication.shared)
     }
@@ -617,6 +621,12 @@ extension Player {
     @objc internal func handleApplicationWillResignActive(_ aNotification: Notification) {
         if self.playbackState == .playing && self.playbackPausesWhenResigningActive {
             self.pause()
+        }
+    }
+
+    @objc internal func handleApplicationDidBecomeActive(_ aNotification: Notification) {
+        if self.playbackState != .playing && self.playbackResumesWhenBecameActive {
+            self.play()
         }
     }
 

--- a/Sources/Player.swift
+++ b/Sources/Player.swift
@@ -185,6 +185,9 @@ open class Player: UIViewController {
         }
     }
 
+    /// Pauses playback automatically when resigning active.
+    open var playbackPausesWhenResigningActive: Bool = true
+    
     /// Pauses playback automatically when backgrounded.
     open var playbackPausesWhenBackgrounded: Bool = true
     
@@ -612,7 +615,7 @@ extension Player {
     // MARK: - handlers
     
     @objc internal func handleApplicationWillResignActive(_ aNotification: Notification) {
-        if self.playbackState == .playing {
+        if self.playbackState == .playing && self.playbackPausesWhenResigningActive {
             self.pause()
         }
     }


### PR DESCRIPTION
Hello!
I have been developing an app lately using Player😸

### Problem

I found a problem that `playbackPausesWhenBackgrounded` property doesn't work well.
And I found the cause of the problem.

When pressed the Home button, Player receives `UIApplicationWillResignActive` notification before receives `UIApplicationDidEnterBackground` notification.
Current handler method for `UIApplicationWillResignActive` is following.
Therefore Player always pauses when background.
```swift
@objc internal func handleApplicationWillResignActive(_ aNotification: Notification) {
    if self.playbackState == .playing {
        self.pause()
    }
}
```

Also, I read issue #166.
This PR is a solution for these two problem.

### Solution
Add `playbackPausesWhenResigningActive` and `playbackResumesWhenBecameActive` properties just like `playbackPausesWhenBackgrounded` and `playbackResumesWhenEnteringForeground`.
And Player controls properly when receive `UIApplication` notifications.


Please review🙇