### PR TITLE
Fix deinit

### DIFF
--- a/Project/Player/ViewController.swift
+++ b/Project/Player/ViewController.swift
@@ -34,7 +34,7 @@ class ViewController: UIViewController {
     
     // MARK: object lifecycle
     deinit {
-        self.player.willMove(toParentViewController: self)
+        self.player.willMove(toParentViewController: nil)
         self.player.view.removeFromSuperview()
         self.player.removeFromParentViewController()
     }

--- a/Project/PlayerTV/ViewController.swift
+++ b/Project/PlayerTV/ViewController.swift
@@ -34,7 +34,7 @@ class ViewController: UIViewController {
 	
 	// MARK: object lifecycle
     deinit {
-        self.player.willMove(toParentViewController: self)
+        self.player.willMove(toParentViewController: nil)
         self.player.view.removeFromSuperview()
         self.player.removeFromParentViewController()
     }


### PR DESCRIPTION
According to the documentation,
> If you are implementing your own container view controller, it must call the willMove(toParent:) method of the child view controller before calling the removeFromParent() method, passing in a parent value of nil.