### PR TITLE
Fixed some delegate methods not being called in the main thread.

### DIFF
--- a/Sources/Player.swift
+++ b/Sources/Player.swift
@@ -223,7 +223,9 @@ open class Player: UIViewController {
     open var playbackState: PlaybackState = .stopped {
         didSet {
             if playbackState != oldValue || !playbackEdgeTriggered {
-                self.playerDelegate?.playerPlaybackStateDidChange(self)
+                self.executeClosureOnMainQueueIfNecessary {
+                    self.playerDelegate?.playerPlaybackStateDidChange(self)
+                }
             }
         }
     }
@@ -232,7 +234,9 @@ open class Player: UIViewController {
     open var bufferingState: BufferingState = .unknown {
         didSet {
             if bufferingState != oldValue || !playbackEdgeTriggered {
-                self.playerDelegate?.playerBufferingStateDidChange(self)
+                self.executeClosureOnMainQueueIfNecessary {
+                    self.playerDelegate?.playerBufferingStateDidChange(self)
+                }
             }
         }
     }


### PR DESCRIPTION
This commit fixes an issue where `playerPlaybackStateDidChange` and `playerBufferingStateDidChange` may not be called in the main thread.

![image](https://user-images.githubusercontent.com/4084679/46073521-bb477b00-c1b7-11e8-9370-40507a7bf4ac.png)
