### PR TITLE
Expose AVPlayer property

### DIFF
--- a/Sources/Player.swift
+++ b/Sources/Player.swift
@@ -948,7 +948,9 @@ public class PlayerView: UIView {
         }
     }
 
-    internal var player: AVPlayer? {
+    // MARK: - public properties
+
+    public var player: AVPlayer? {
         get {
             return self.playerLayer.player
         }
@@ -957,8 +959,6 @@ public class PlayerView: UIView {
             self.playerLayer.isHidden = (self.playerLayer.player == nil)
         }
     }
-
-    // MARK: - public properties
 
     public var playerBackgroundColor: UIColor? {
         get {


### PR DESCRIPTION
This is added so we can remove and restore AVPlayer on backgrounding and foregrounding respectively per Apple's documentation
https://developer.apple.com/library/archive/qa/qa1668/_index.html#//apple_ref/doc/uid/DTS40010209-CH1-VIDEO

This could possibly be done inside `Player` itself but not sure if we want to add more flags for background/foreground changes.